### PR TITLE
Remove alignas(32) from EffectContext

### DIFF
--- a/sdk/src/backends/dx12/ffx_dx12.cpp
+++ b/sdk/src/backends/dx12/ffx_dx12.cpp
@@ -142,7 +142,7 @@ typedef struct BackendContext_DX12 {
 
     IDXGIFactory*           dxgiFactory = nullptr;
 
-    typedef struct alignas(32) EffectContext {
+    typedef struct EffectContext {
 
         // Effect identifier -- used for various resource callbacks to application
         FfxEffect           effectId;

--- a/sdk/src/backends/vk/ffx_vk.cpp
+++ b/sdk/src/backends/vk/ffx_vk.cpp
@@ -206,7 +206,7 @@ typedef struct BackendContext_VK {
     VkPipelineStageFlags    srcStageMask = 0;
     VkPipelineStageFlags    dstStageMask = 0;
 
-    typedef struct alignas(32) EffectContext {
+    typedef struct EffectContext {
 
         // Effect identifier -- used for various resource callbacks to application
         FfxEffect           effectId;


### PR DESCRIPTION
Hi, thanks for doing all the the work to get this working on linux! I've been writing some rust bindings at https://github.com/expenses/ffx1-rs. I was having some issues with the scratch buffer that gets passed to `ffxGetInterfaceVK` where it was causing `(signal: 11, SIGSEGV: invalid memory reference)`.

```
0x0000555556842b3c in CreateBackendContextVK(FfxInterface*, FfxEffect, FfxEffectBindlessConfig*, unsigned int*) ()
(gdb) bt
#0  0x0000555556842b3c in CreateBackendContextVK(FfxInterface*, FfxEffect, FfxEffectBindlessConfig*, unsigned int*) ()
#1  0x0000555556859560 in fsr3upscalerCreate(FfxFsr3UpscalerContext_Private*, FfxFsr3UpscalerContextDescription const*) ()
#2  0x00005555568284ab in fsr3_rs2::UpscalerContext::create (desc=0x7ffff77fc8e8) at src/lib.rs:77
```

The key section is when it sets all the arrays:

https://github.com/DethRaid/FidelityFX-SDK-Linux/blob/e6cf6e4becf066a1218e0f7fc12379c89aed56ea/sdk/src/backends/vk/ffx_vk.cpp#L1402-L1454

Because `BackendContext_VK` doesn't specify any particular alignment, `uint8_t* pMem = (uint8_t*)((BackendContext_VK*)(backendContext + 1)); ` creates a pointer that is unaligned, causing issues when `EffectContext` requires 32-bit alignment. I'm pretty sure there are other ways to solve this, but removing `alignas(32)` from the struct (dx12 as well for good measure) has worked for me. Aligning `BackendContext_VK` also works but seems more fragile.

Happy to hear any other ideas! 